### PR TITLE
Closing the database causes crashes

### DIFF
--- a/src/android/LocalStorage.java
+++ b/src/android/LocalStorage.java
@@ -35,7 +35,6 @@ public class LocalStorage {
             results.add(cursor.getString(1));
         }
         cursor.close();
-        database.close();
         return results;
     }
 
@@ -58,7 +57,6 @@ public class LocalStorage {
                 value = cursor.getString(1);
             }
             cursor.close();
-            database.close();
         }
         return value;
     }
@@ -85,7 +83,6 @@ public class LocalStorage {
                 database.insert(LocalStorageDBHelper.LOCALSTORAGE_TABLE_NAME,
                         null, values);
             }
-            database.close();
         }
     }
 
@@ -100,7 +97,6 @@ public class LocalStorage {
             database.delete(LocalStorageDBHelper.LOCALSTORAGE_TABLE_NAME,
                     LocalStorageDBHelper.LOCALSTORAGE_ID + "='" + key + "'",
                     null);
-            database.close();
         }
     }
 
@@ -111,6 +107,5 @@ public class LocalStorage {
         database = localStorageDBHelper.getWritableDatabase();
         database.delete(LocalStorageDBHelper.LOCALSTORAGE_TABLE_NAME, null,
                 null);
-        database.close();
     }
 }


### PR DESCRIPTION
As found in the comments of #158 databases shouldn't be closed as per this comment from a Google Engineer on the subject. After some testing I have not been able to replicate the issue after removing all instances of database.close()